### PR TITLE
Add message callback to install_imports

### DIFF
--- a/lib/pyodide_worker_runner.py
+++ b/lib/pyodide_worker_runner.py
@@ -17,13 +17,13 @@ def find_imports_to_install(imports):
     return to_install
 
 async def install_imports(source_code_or_imports, message_callback=lambda *args: None):
-    if isinstance(source_code_or_imports, list):
-        imports = source_code_or_imports
-    else:
+    if isinstance(source_code_or_imports, str):
         try:
             imports = pyodide.find_imports(source_code_or_imports)
         except SyntaxError:
             return
+    else:
+        imports = source_code_or_imports
 
     to_install = find_imports_to_install(imports)
     if to_install:

--- a/lib/pyodide_worker_runner.py
+++ b/lib/pyodide_worker_runner.py
@@ -29,6 +29,12 @@ async def install_imports(source_code_or_imports, message_callback=lambda *args:
     if to_install:
         def import_cb(typ, imports):
             return message_callback(dict(type=typ, imports=imports))
+        
+        to_package_name = pyodide_js._module._import_name_to_package_name.to_py()
+        to_install_entries = [
+            dict(module=mod, package=to_package_name.get(mod, mod)) for mod in to_install
+        ]
+        import_cb("loading", to_install_entries)
         try:
             import micropip  # noqa
         except ModuleNotFoundError:
@@ -37,11 +43,6 @@ async def install_imports(source_code_or_imports, message_callback=lambda *args:
             import micropip  # noqa
             import_cb("loaded", [dict(module="micropip", package="micropip")])
 
-        to_package_name = pyodide_js._module._import_name_to_package_name.to_py()
-        to_install_entries = [
-            dict(module=mod, package=to_package_name.get(mod, mod)) for mod in to_install
-        ]
-        import_cb("loading", to_install_entries)
         for entry in to_install:
             import_cb("loading", entry)
             await micropip.install(entry["package"])

--- a/lib/pyodide_worker_runner.py
+++ b/lib/pyodide_worker_runner.py
@@ -17,7 +17,7 @@ def find_imports_to_install(imports):
     return to_install
 
 
-async def install_imports(source_code):
+async def install_imports(source_code, message_callback=lambda *args: None):
     try:
         imports = pyodide.find_imports(source_code)
     except SyntaxError:
@@ -30,7 +30,9 @@ async def install_imports(source_code):
         except ModuleNotFoundError:
             await pyodide_js.loadPackage("micropip")
             import micropip  # noqa
-
+        module_names = ", ".join(to_install)
+        message_callback(f"Loading {module_names}")
         to_package_name = pyodide_js._module._import_name_to_package_name.to_py()
         packages_names = [to_package_name.get(mod, mod) for mod in to_install]
         await micropip.install(packages_names)
+        message_callback(f"Loaded {module_names}")

--- a/lib/pyodide_worker_runner.py
+++ b/lib/pyodide_worker_runner.py
@@ -27,24 +27,21 @@ async def install_imports(source_code_or_imports, message_callback=lambda *args:
 
     to_install = find_imports_to_install(imports)
     if to_install:
-        def import_cb(typ, imports):
-            return message_callback(dict(type=typ, imports=imports))
-        
         to_package_name = pyodide_js._module._import_name_to_package_name.to_py()
         to_install_entries = [
             dict(module=mod, package=to_package_name.get(mod, mod)) for mod in to_install
         ]
-        import_cb("loading_all", to_install_entries)
+        message_callback("loading_all", to_install_entries)
         try:
             import micropip  # noqa
         except ModuleNotFoundError:
-            import_cb("loading_micropip", [dict(module="micropip", package="micropip")])
+            message_callback("loading_micropip", [dict(module="micropip", package="micropip")])
             await pyodide_js.loadPackage("micropip")
             import micropip  # noqa
-            import_cb("loaded_micropip", [dict(module="micropip", package="micropip")])
+            message_callback("loaded_micropip", [dict(module="micropip", package="micropip")])
 
         for entry in to_install:
-            import_cb("loading_one", entry)
+            message_callback("loading_one", entry)
             await micropip.install(entry["package"])
-            import_cb("loaded_one", entry)
-        import_cb("loaded_all", to_install_entries)
+            message_callback("loaded_one", entry)
+        message_callback("loaded_all", to_install_entries)

--- a/lib/pyodide_worker_runner.py
+++ b/lib/pyodide_worker_runner.py
@@ -34,17 +34,17 @@ async def install_imports(source_code_or_imports, message_callback=lambda *args:
         to_install_entries = [
             dict(module=mod, package=to_package_name.get(mod, mod)) for mod in to_install
         ]
-        import_cb("loading", to_install_entries)
+        import_cb("loading_all", to_install_entries)
         try:
             import micropip  # noqa
         except ModuleNotFoundError:
-            import_cb("loading", [dict(module="micropip", package="micropip")])
+            import_cb("loading_micropip", [dict(module="micropip", package="micropip")])
             await pyodide_js.loadPackage("micropip")
             import micropip  # noqa
-            import_cb("loaded", [dict(module="micropip", package="micropip")])
+            import_cb("loaded_micropip", [dict(module="micropip", package="micropip")])
 
         for entry in to_install:
-            import_cb("loading", entry)
+            import_cb("loading_one", entry)
             await micropip.install(entry["package"])
-            import_cb("loaded", entry)
-        import_cb("loaded", to_install_entries)
+            import_cb("loaded_one", entry)
+        import_cb("loaded_all", to_install_entries)


### PR DESCRIPTION
This PR adds an optional message callback to install_imports so users can keep track of imports that are happening automatically.
This functionality is very useful in the case of https://github.com/dodona-edu/papyros/pull/178.