### PR TITLE
Use correct entry list

### DIFF
--- a/lib/pyodide_worker_runner.py
+++ b/lib/pyodide_worker_runner.py
@@ -8,12 +8,13 @@ sys.setrecursionlimit(500)
 
 
 def find_imports_to_install(imports):
+    to_package_name = pyodide_js._module._import_name_to_package_name.to_py()
     to_install = []
     for module in imports:
         try:
             importlib.import_module(module)
         except ModuleNotFoundError:
-            to_install.append(module)
+            to_install.append(dict(module=module, package=to_package_name.get(module, module)))
     return to_install
 
 async def install_imports(source_code_or_imports, message_callback=lambda *args: None):
@@ -27,21 +28,18 @@ async def install_imports(source_code_or_imports, message_callback=lambda *args:
 
     to_install = find_imports_to_install(imports)
     if to_install:
-        to_package_name = pyodide_js._module._import_name_to_package_name.to_py()
-        to_install_entries = [
-            dict(module=mod, package=to_package_name.get(mod, mod)) for mod in to_install
-        ]
-        message_callback("loading_all", to_install_entries)
+        message_callback("loading_all", to_install)
         try:
             import micropip  # noqa
         except ModuleNotFoundError:
-            message_callback("loading_micropip", [dict(module="micropip", package="micropip")])
+            micropip_entry = dict(module="micropip", package="micropip")
+            message_callback("loading_micropip", micropip_entry)
             await pyodide_js.loadPackage("micropip")
             import micropip  # noqa
-            message_callback("loaded_micropip", [dict(module="micropip", package="micropip")])
+            message_callback("loaded_micropip", micropip_entry)
 
-        for entry in to_install_entries:
+        for entry in to_install:
             message_callback("loading_one", entry)
             await micropip.install(entry["package"])
             message_callback("loaded_one", entry)
-        message_callback("loaded_all", to_install_entries)
+        message_callback("loaded_all", to_install)

--- a/lib/pyodide_worker_runner.py
+++ b/lib/pyodide_worker_runner.py
@@ -40,7 +40,7 @@ async def install_imports(source_code_or_imports, message_callback=lambda *args:
             import micropip  # noqa
             message_callback("loaded_micropip", [dict(module="micropip", package="micropip")])
 
-        for entry in to_install:
+        for entry in to_install_entries:
             message_callback("loading_one", entry)
             await micropip.install(entry["package"])
             message_callback("loaded_one", entry)


### PR DESCRIPTION
The wrong list was being used when actually installing imports using micropip.
Should be merged and released ASAP as using the new version does not work right now.
Not sure how we both missed this :P properly naming variables truly is one of the hardest things in programming.