### PR TITLE
Fix building types

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -79,7 +79,7 @@ export function versionInfo(version: string): number[] {
 export async function loadPyodideAndPackage(
   packageOptions: PackageOptions,
   pyodideLoader: PyodideLoader = defaultPyodideLoader,
-) {
+) : Promise<PyodideInterface> {
   let {format, extractDir, url} = packageOptions;
   extractDir = extractDir || "/tmp/";
 


### PR DESCRIPTION
This pr fixes the building of types.

The issue was typescript breaking because it autodetected the return type of the function to be `Promise<PyodideAPI>`. This returned an error as `PyodideAPI` is not exported by pyodide and thus cannot be used as the type of an exported function.

It is fixed by explicitly specifying the return type.

The resulting code is the same as pyodide defines:
```typescript
export declare type PyodideInterface = typeof PyodideAPI;
```

Closes https://github.com/alexmojaki/pyodide-worker-runner/issues/32